### PR TITLE
Update dialog.tsx - Remove backdrop-blur-sm from overlay

### DIFF
--- a/apps/docs/src/registry/ui/dialog.tsx
+++ b/apps/docs/src/registry/ui/dialog.tsx
@@ -30,7 +30,7 @@ const DialogOverlay = <T extends ValidComponent = "div">(
   return (
     <DialogPrimitive.Overlay
       class={cn(
-        "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[expanded]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[expanded]:fade-in-0",
+        "fixed inset-0 z-50 bg-background/80 data-[expanded]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[expanded]:fade-in-0",
         props.class
       )}
       {...rest}


### PR DESCRIPTION
Backdrop-filter:blur(..) causes lagging scroll bars in Chrome. Shadcn has removed (never used?!) backdrop-blur-sm on the DialogOverlay component.[Shadcn - Dialog]( https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/default/ui/dialog.tsx)