### PR TITLE
fix: missing opening sheet animation

### DIFF
--- a/apps/docs/src/registry/ui/sheet.tsx
+++ b/apps/docs/src/registry/ui/sheet.tsx
@@ -61,7 +61,7 @@ const sheetVariants = cva(
         top: "inset-x-0 top-0 border-b data-[closed=]:slide-out-to-top data-[expanded=]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t data-[closed=]:slide-out-to-bottom data-[expanded=]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[closed=]:slide-out-to-left data-[expanded]:slide-in-from-left sm:max-w-sm",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[closed=]:slide-out-to-left data-[expanded=]:slide-in-from-left sm:max-w-sm",
         right:
           "inset-y-0 right-0 h-full w-3/4 border-l data-[closed=]:slide-out-to-right data-[expanded=]:slide-in-from-right sm:max-w-sm"
       }


### PR DESCRIPTION
Somehow it did not include a equal for the animation to appear just for the left position