### PR TITLE
Specify the version of tailwindcss to install

### DIFF
--- a/apps/docs/src/routes/(app)/docs/installation/vite.mdx
+++ b/apps/docs/src/routes/(app)/docs/installation/vite.mdx
@@ -23,7 +23,7 @@ When asked make sure to use Solid:
 Install `tailwindcss` and its peer dependencies, then generate your `tailwind.config.js` and `postcss.config.js` files:
 
 ```bash
-npm install -D tailwindcss postcss autoprefixer
+npm install -D tailwindcss@3 postcss autoprefixer
 npx tailwindcss init -p
 ```
 


### PR DESCRIPTION
The original command `npm install -D tailwindcss postcss autoprefixer` will install tailwindcss v4, which does not support `init` command and will raises error `Could Not Determine Executable to Run`; so we need to install v3 here instead.